### PR TITLE
rails g migration AddUserIdToArticles user:references

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   validates :account, presence: true
   validates :account, uniqueness: true
+
+  has_many :articles
 end

--- a/db/migrate/20190702120801_add_user_id_to_articles.rb
+++ b/db/migrate/20190702120801_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_15_142816) do
+ActiveRecord::Schema.define(version: 2019_07_02_120801) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -27,4 +29,5 @@ ActiveRecord::Schema.define(version: 2019_06_15_142816) do
     t.string "email"
   end
 
+  add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
- articlesテーブルにusersテーブルを紐付け（１対多）
references を使ってマイグレーションファイル作成
Userモデルに外部キーを設定、indexを貼る

- UserモデルとArticleモデルの紐付け
has_meny , belongs_to を追記